### PR TITLE
feat(enable): persistently add poof’s bin dir to shell PATH

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,6 +468,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "filetime"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,6 +522,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,6 +551,17 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -555,6 +587,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-sink",
@@ -990,6 +1023,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,6 +1148,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "password-hash"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1171,8 +1237,10 @@ dependencies = [
  "reqwest",
  "semver",
  "serde",
+ "serial_test",
  "sevenz-rust2",
  "tar",
+ "tempfile",
  "xz2",
  "zip",
 ]
@@ -1528,6 +1596,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
+name = "scc"
+version = "2.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22b2d775fb28f245817589471dd49c5edf64237f4a19d10ce9a92ff4651a27f4"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "584e070911c7017da6cb2eb0788d09f43d789029b5877d3e5ecc8acf86ceee21"
+
+[[package]]
 name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1575,6 +1664,31 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1704,6 +1818,20 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "getrandom 0.3.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,5 +48,9 @@ regex = "1.11.1"
 rayon = "1.10.0"
 semver = "1.0.26"
 
+[dev-dependencies]
+tempfile = "3" 
+serial_test = "3"
+
 [build-dependencies]
 chrono = "0.4"

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Commands:
   list      List installed binaries and their versions
   check     Check if poof's bin directory is in the PATH
   version   Show version information
+  enable    Persistently add poof’s bin directory to your shell PATH
   help      Print this message or the help of the given subcommand(s)
 
 Options:
@@ -142,6 +143,24 @@ Cache of downloaded releases:
 
 - **Linux**: `~/.cache/poof`
 - **macOS**: `~/Library/Caches/poof`
+
+## Enable
+
+To enable Poof in every new terminal session, run:
+
+```bash
+poof enable
+```
+
+This will append a line to your `~/.bashrc` or `~/.zshrc` that adds poof’s bin directory (from `dirs::data_dir()/poof/bin`) to your `$PATH`.
+
+You can safely re-run `poof enable`: it will detect the existing line and do nothing if it’s already present.
+
+Afterwards, reload your shell:
+
+```bash
+source ~/.bashrc   # or `source ~/.zshrc`, or just open a new terminal
+```
 
 ## Disable
 

--- a/src/commands/enable.rs
+++ b/src/commands/enable.rs
@@ -1,0 +1,225 @@
+//! sibellavia: persistently add poof's bin directory to PATH
+//! here I am using `eprintln` and `println`, but we can evaluate
+//! using `anyhow` instead! Also, for now I'm not considering Windows.
+//! TODO: add support for Windows.
+
+use std::{fs::OpenOptions, io::Write, path::PathBuf};
+
+use crate::datadirs::get_bin_dir;
+
+pub fn run() {
+    /* 1 ─ get the directory that holds poof's executables */
+    let bin_dir = match get_bin_dir() {
+        Some(p) => p,
+        None => {
+            eprintln!("poof‑enable: cannot locate bin directory");
+            return;
+        }
+    };
+    let bin = bin_dir.to_string_lossy();
+
+    /* 2 ─ pick which startup script (.bashrc or .zshrc) to modify */
+    let home = match dirs::home_dir() {
+        Some(h) => h,
+        None => {
+            eprintln!("poof‑enable: cannot find $HOME");
+            return;
+        }
+    };
+    let shell = std::env::var("SHELL").unwrap_or_default();
+    let rc: PathBuf = if shell.ends_with("zsh") {
+        home.join(".zshrc")
+    } else {
+        home.join(".bashrc") 
+    };
+
+    /* 3 ─ if the PATH line is already there, do nothing */
+    if let Ok(text) = std::fs::read_to_string(&rc) {
+        if text.contains(bin.as_ref()) {
+            println!("poof already enabled in {}", rc.display());
+            return;
+        }
+    }
+
+    /* 4 ─ append the export line */
+    let mut file = match OpenOptions::new().create(true).append(true).open(&rc) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("poof‑enable: cannot open {}: {}", rc.display(), e);
+            return;
+        }
+    };
+
+    if writeln!(file, "\n# added by poof\nexport PATH=\"{}:$PATH\"", bin).is_err() {
+        eprintln!("poof‑enable: could not write to {}", rc.display());
+        return;
+    }
+
+    println!(
+        "🪄 Added poof to {}.\n   Run `source {0}` or open a new terminal.",
+        rc.display()
+    );
+}
+
+// ------------------------------------------------------------------
+//                       unit‑tests
+// I'm not sure a test suite is provided, I couldn't find one
+// so for now I'm just dropping some unit tests here
+// ------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    use super::run;
+    use crate::datadirs::get_bin_dir;
+    use serial_test::serial;
+    use std::{env, fs};
+    use tempfile::TempDir;
+
+    /// prepare HOME and XDG_DATA_HOME, then create the real bin dir
+    fn create_fake_bin(home: &TempDir) {
+        // point datadirs::get_bin_dir() at our temp dir
+        env::set_var("HOME", home.path());
+        env::set_var("XDG_DATA_HOME", home.path());
+
+        // now this is "<temp>/poof/bin"
+        let bin = get_bin_dir().unwrap();
+        fs::create_dir_all(&bin).unwrap();
+    }
+
+    /// read the contents of the given rc‐file
+    fn get_rc_contents(rc: &std::path::Path) -> String {
+        fs::read_to_string(rc).unwrap_or_default()
+    }
+
+    #[serial]
+    #[test]
+    /// test that bashrc is written to and running twice doesn't duplicate
+    fn bashrc_idempotent() {
+        let temp_home = TempDir::new().unwrap();
+        // shell + HOME are set inside create_fake_bin
+        create_fake_bin(&temp_home);
+        env::set_var("SHELL", "/bin/bash");
+
+        // run twice for idempotence
+        run();
+        run();
+
+        let rc_path = temp_home.path().join(".bashrc");
+        let contents = get_rc_contents(&rc_path);
+
+        // Build the exact expected export from the same helper
+        let binding = get_bin_dir().unwrap();
+        let bin = binding.to_string_lossy();
+        let expected = format!("export PATH=\"{}:$PATH\"", bin);
+
+        assert_eq!(
+            contents.matches(&expected).count(),
+            1,
+            "export line should appear exactly once"
+        );
+    }
+
+    #[serial]
+    #[test]
+    /// test that zshrc is written to
+    fn writes_to_zshrc() {
+        let temp_home = TempDir::new().unwrap();
+        create_fake_bin(&temp_home);
+        env::set_var("SHELL", "/usr/bin/zsh");
+
+        run();
+
+        let rc_path = temp_home.path().join(".zshrc");
+        let contents = get_rc_contents(&rc_path);
+        assert!(
+            contents.contains("export PATH="),
+            ".zshrc should contain an export line"
+        );
+    }
+
+    #[serial]
+    #[test]
+    /// test that zshrc is written to and running twice doesn't duplicate
+    fn zsh_idempotent() {
+        let temp_home = TempDir::new().unwrap();
+        create_fake_bin(&temp_home);
+        env::set_var("SHELL", "/usr/bin/zsh");
+
+        run();
+        run();
+
+        let rc_path = temp_home.path().join(".zshrc");
+        let contents = get_rc_contents(&rc_path);
+
+        let binding = get_bin_dir().unwrap();
+        let bin = binding.to_string_lossy();
+        let line = format!("export PATH=\"{}:$PATH\"", bin);
+
+        assert_eq!(
+            contents.matches(&line).count(),
+            1,
+            "zsh idempotence: export line should appear exactly once"
+        );
+    }
+
+    #[serial]
+    #[test]
+    /// test that unknown shell defaults to bash
+    fn unknown_shell_defaults_to_bash() {
+        let temp_home = TempDir::new().unwrap();
+        create_fake_bin(&temp_home);
+        env::remove_var("SHELL");
+
+        run();
+
+        let contents = get_rc_contents(&temp_home.path().join(".bashrc"));
+        assert!(
+            contents.contains("export PATH="),
+            "unknown-shell fallback should write to .bashrc"
+        );
+    }
+
+    #[serial]
+    #[test]
+    /// test that existing rc file content is preserved
+    fn preserves_existing_content() {
+        let temp_home = TempDir::new().unwrap();
+        create_fake_bin(&temp_home);
+        env::set_var("SHELL", "/bin/bash");
+
+        // Pre-seed .bashrc
+        let rc_path = temp_home.path().join(".bashrc");
+        fs::write(&rc_path, "PRE_EXISTING_LINE\n").unwrap();
+
+        run();
+
+        let contents = get_rc_contents(&rc_path);
+        let binding = get_bin_dir().unwrap();
+        let bin = binding.to_string_lossy();
+
+        assert!(
+            contents.contains("PRE_EXISTING_LINE"),
+            "existing content must be preserved"
+        );
+        assert!(
+            contents.contains(&format!("export PATH=\"{}:$PATH\"", bin)),
+            "export line must be appended"
+        );
+    }
+
+    #[serial]
+    #[test]
+    /// test that comment marker is added to rc file
+    fn adds_comment_marker() {
+        let temp_home = TempDir::new().unwrap();
+        create_fake_bin(&temp_home);
+        env::set_var("SHELL", "/bin/bash");
+
+        run();
+
+        let contents = get_rc_contents(&temp_home.path().join(".bashrc"));
+        assert!(
+            contents.contains("# added by poof"),
+            "comment marker must be present"
+        );
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,3 +4,4 @@ pub mod info;
 pub mod install;
 pub mod list;
 pub mod make_default;
+pub mod enable;

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,6 +76,9 @@ enum Cmd {
 
     /// Show version information
     Version,
+
+    /// Persistently add poof’s bin directory to your shell PATH
+    Enable,
 }
 
 #[derive(Parser)]
@@ -196,6 +199,9 @@ fn main() {
         }
         Cmd::Info => {
             commands::info::show_info();
+        }
+        Cmd::Enable => {
+            commands::enable::run();
         }
     }
 }


### PR DESCRIPTION
excited to contribute to poof :)

this PR implements the `poof enable` command to persistently add poof’s bin directory to the user’s shell PATH by appending to `~/.bashrc` or `~/.zshrc`.

here's what I did:

- added an `Enable` variant to the cli enum and dispatches it in `main.rs`
- implemented `src/commands/enable.rs`. it skips if already present, detects the shell (zshrc or bashrc) and adds a comment for easy removal
- provided in-file unit tests covering: bash write + skips if present; zsh write + skips if present; fallback when $SHELL is unset (it defaults to bash); preservation of pre-existing rc-file content, presence of the `# added by poof` marker 
- updated the README to add `enable` to the commands list, with usage examples

note: installing or updating the `poof` binary itself is out of scope and should be done separately (I just followed the short requirement in ROADMAP. native windows support is not yet implemented (I added a `TODO:`). we could refactor error handling to use anyhow for cleaner propagation, but for now I kept the code simple using `eprintln` and explicit checks.