### PR TITLE
feat: support install of unarchived/uncompressed assets

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -23,3 +23,6 @@ pub const SUPPORTED_EXTENSIONS: [&str; 12] = [
 
 // other constants
 pub const UNKNOWN: &str = "Unknown";
+
+// separators
+pub const FILENAME_SEPARATORS: [&str; 3] = ["_", "-", "."];

--- a/src/files/archives.rs
+++ b/src/files/archives.rs
@@ -1,8 +1,7 @@
-use crate::files::magic::{
-    BZIP2_MAGIC, GZIP_MAGIC, SEVENZ_MAGIC, TAR_MAGIC, TAR_MAGIC_OFFSET, XZ_MAGIC, ZIP_MAGIC,
-};
+use crate::files::magic::*;
 use crate::files::utils::get_file_extension;
 use crate::models::binary_container::BinaryContainer;
+
 use bzip2::read::BzDecoder;
 use flate2::read::GzDecoder;
 use log::{debug, error};

--- a/src/files/filesys.rs
+++ b/src/files/filesys.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use crate::files::magic::is_exec_by_magic_number;
 use crate::files::utils::strip_supported_extensions;
 
-pub fn find_exec_files_in_dir(dir: &PathBuf) -> Vec<PathBuf> {
+pub fn find_exec_files_in_dir(dir: &Path) -> Vec<PathBuf> {
     let mut result: Vec<PathBuf> = Vec::new();
     if let Ok(entries) = std::fs::read_dir(dir) {
         for entry in entries.flatten() {

--- a/src/files/filesys.rs
+++ b/src/files/filesys.rs
@@ -1,72 +1,8 @@
 use log::{debug, warn};
-use std::{
-    fs::File,
-    io::Read,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
-#[cfg(target_os = "linux")]
-use crate::files::magic::ELF_MAGIC;
-#[cfg(target_os = "macos")]
-use crate::files::magic::MACHO_MAGIC_NUMBERS;
-#[cfg(target_os = "windows")]
-use crate::files::magic::PE_MAGIC;
-
+use crate::files::magic::is_exec_by_magic_number;
 use crate::files::utils::strip_supported_extensions;
-
-#[cfg(target_os = "linux")]
-fn is_exec_magic(buffer: &[u8; 4]) -> bool {
-    // Linux expects ELF binaries
-    buffer == &ELF_MAGIC // ELF
-}
-
-#[cfg(target_os = "windows")]
-fn is_exec_magic(buffer: &[u8; 4]) -> bool {
-    // Windows expects PE binaries (MZ header).
-    // Checking only the first two bytes because the other two may change,
-    // as they depend on the DOS stub.
-    buffer[..2] == core::magic::PE_MAGIC
-}
-
-#[cfg(target_os = "macos")]
-fn is_exec_magic(buffer: &[u8; 4]) -> bool {
-    // macOS expects Mach-O formats
-    MACHO_MAGIC_NUMBERS.contains(buffer)
-}
-
-#[cfg(not(target_os = "windows"))]
-fn is_exec_by_magic_number(path: &PathBuf) -> bool {
-    if let Ok(mut file) = File::open(path) {
-        let mut buffer = [0u8; 4];
-        if file.read_exact(&mut buffer).is_ok() {
-            return is_exec_magic(&buffer);
-        }
-    }
-    false
-}
-
-#[cfg(target_os = "windows")]
-fn is_exec_by_magic_number(path: &PathBuf) -> bool {
-    // We need to first check the file extension for Windows binaries,
-    // as it uses the PE format (MZ header) for file types other than
-    // .exe (e.g. .dll, .sys, etc.).
-    // Then we check the first two bytes of the .exe file because the
-    // other two may change (they depend on the DOS stub).
-    let extension = path
-        .extension()
-        .and_then(|s| s.to_str())
-        .unwrap_or_default();
-    if extension != "exe" {
-        return false;
-    }
-    if let Ok(mut file) = File::open(path) {
-        let mut buffer = [0u8; 4];
-        if file.read_exact(&mut buffer).is_ok() {
-            return is_exec_magic(&buffer);
-        }
-    }
-    false
-}
 
 pub fn find_exec_files_in_dir(dir: &PathBuf) -> Vec<PathBuf> {
     let mut result: Vec<PathBuf> = Vec::new();

--- a/src/files/filesys.rs
+++ b/src/files/filesys.rs
@@ -5,14 +5,14 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::constants::SUPPORTED_EXTENSIONS;
 #[cfg(target_os = "linux")]
 use crate::files::magic::ELF_MAGIC;
 #[cfg(target_os = "macos")]
 use crate::files::magic::MACHO_MAGIC_NUMBERS;
 #[cfg(target_os = "windows")]
 use crate::files::magic::PE_MAGIC;
-use crate::files::utils::get_file_name;
+
+use crate::files::utils::strip_supported_extensions;
 
 #[cfg(target_os = "linux")]
 fn is_exec_magic(buffer: &[u8; 4]) -> bool {
@@ -83,18 +83,6 @@ pub fn find_exec_files_in_dir(dir: &PathBuf) -> Vec<PathBuf> {
         }
     }
     result
-}
-
-fn strip_supported_extensions(path: &Path) -> &str {
-    let filename = get_file_name(path);
-    SUPPORTED_EXTENSIONS
-        .iter()
-        .find_map(|ext| filename.strip_suffix(ext))
-        .unwrap_or_else(|| {
-            path.file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or(filename)
-        })
 }
 
 pub fn find_exec_files_from_extracted_archive(archive_path: &Path) -> Vec<PathBuf> {

--- a/src/files/magic.rs
+++ b/src/files/magic.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, io::Read, path::PathBuf};
+use std::{fs::File, io::Read, path::Path};
 
 // Magic number constants for file format detection
 
@@ -50,7 +50,7 @@ fn is_exec_magic(buffer: &[u8; 4]) -> bool {
 }
 
 #[cfg(not(target_os = "windows"))]
-pub fn is_exec_by_magic_number(path: &PathBuf) -> bool {
+pub fn is_exec_by_magic_number(path: &Path) -> bool {
     if let Ok(mut file) = File::open(path) {
         let mut buffer = [0u8; 4];
         if file.read_exact(&mut buffer).is_ok() {
@@ -61,7 +61,7 @@ pub fn is_exec_by_magic_number(path: &PathBuf) -> bool {
 }
 
 #[cfg(target_os = "windows")]
-pub fn is_exec_by_magic_number(path: &PathBuf) -> bool {
+pub fn is_exec_by_magic_number(path: &Path) -> bool {
     // We need to first check the file extension for Windows binaries,
     // as it uses the PE format (MZ header) for file types other than
     // .exe (e.g. .dll, .sys, etc.).

--- a/src/files/magic.rs
+++ b/src/files/magic.rs
@@ -1,3 +1,5 @@
+use std::{fs::File, io::Read, path::PathBuf};
+
 // Magic number constants for file format detection
 
 #[cfg(target_os = "macos")]
@@ -26,3 +28,57 @@ pub const BZIP2_MAGIC: &[u8] = &[0x42, 0x5A, 0x68]; // "BZh"
 pub const TAR_MAGIC_OFFSET: usize = 257;
 pub const TAR_MAGIC: &[u8] = b"ustar";
 pub const SEVENZ_MAGIC: &[u8] = &[0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C]; // 7z signature
+
+#[cfg(target_os = "linux")]
+fn is_exec_magic(buffer: &[u8; 4]) -> bool {
+    // Linux expects ELF binaries
+    buffer == &ELF_MAGIC // ELF
+}
+
+#[cfg(target_os = "windows")]
+fn is_exec_magic(buffer: &[u8; 4]) -> bool {
+    // Windows expects PE binaries (MZ header).
+    // Checking only the first two bytes because the other two may change,
+    // as they depend on the DOS stub.
+    buffer[..2] == core::magic::PE_MAGIC
+}
+
+#[cfg(target_os = "macos")]
+fn is_exec_magic(buffer: &[u8; 4]) -> bool {
+    // macOS expects Mach-O formats
+    MACHO_MAGIC_NUMBERS.contains(buffer)
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn is_exec_by_magic_number(path: &PathBuf) -> bool {
+    if let Ok(mut file) = File::open(path) {
+        let mut buffer = [0u8; 4];
+        if file.read_exact(&mut buffer).is_ok() {
+            return is_exec_magic(&buffer);
+        }
+    }
+    false
+}
+
+#[cfg(target_os = "windows")]
+pub fn is_exec_by_magic_number(path: &PathBuf) -> bool {
+    // We need to first check the file extension for Windows binaries,
+    // as it uses the PE format (MZ header) for file types other than
+    // .exe (e.g. .dll, .sys, etc.).
+    // Then we check the first two bytes of the .exe file because the
+    // other two may change (they depend on the DOS stub).
+    let extension = path
+        .extension()
+        .and_then(|s| s.to_str())
+        .unwrap_or_default();
+    if extension != "exe" {
+        return false;
+    }
+    if let Ok(mut file) = File::open(path) {
+        let mut buffer = [0u8; 4];
+        if file.read_exact(&mut buffer).is_ok() {
+            return is_exec_magic(&buffer);
+        }
+    }
+    false
+}

--- a/src/files/utils.rs
+++ b/src/files/utils.rs
@@ -1,5 +1,9 @@
+use crate::constants::FILENAME_SEPARATORS;
 use crate::constants::SUPPORTED_EXTENSIONS;
-use std::path::Path;
+use std::{
+    ffi::{OsStr, OsString},
+    path::Path,
+};
 
 pub fn get_file_extension(archive_path: &Path) -> &str {
     let filename = archive_path
@@ -40,4 +44,135 @@ pub fn strip_supported_extensions(path: &Path) -> &str {
                 .and_then(|s| s.to_str())
                 .unwrap_or(filename)
         })
+}
+
+pub fn get_stem_name_trimmed_at_first_separator(file_name: &OsStr) -> OsString {
+    let x = FILENAME_SEPARATORS
+        .iter()
+        .fold(file_name.to_string_lossy().to_string(), |acc, sep| {
+            if let Some(index) = acc.find(sep) {
+                acc[..index].to_string()
+            } else {
+                acc
+            }
+        })
+        .trim_end_matches(|c: char| c.is_ascii_digit())
+        .to_string();
+    OsString::from(x)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::OsStr;
+
+    #[test]
+    fn test_get_stem_name_trimmed_at_first_separator_with_underscore() {
+        let file_name = OsStr::new("myapp_v1.2.3_linux_amd64");
+        let result = get_stem_name_trimmed_at_first_separator(file_name);
+        assert_eq!(result, OsString::from("myapp"));
+    }
+
+    #[test]
+    fn test_get_stem_name_trimmed_at_first_separator_with_hyphen() {
+        let file_name = OsStr::new("myapp-v1.2.3-linux-amd64");
+        let result = get_stem_name_trimmed_at_first_separator(file_name);
+        assert_eq!(result, OsString::from("myapp"));
+    }
+
+    #[test]
+    fn test_get_stem_name_trimmed_at_first_separator_with_dot() {
+        let file_name = OsStr::new("myapp.v1.2.3.linux.amd64");
+        let result = get_stem_name_trimmed_at_first_separator(file_name);
+        assert_eq!(result, OsString::from("myapp"));
+    }
+
+    #[test]
+    fn test_get_stem_name_trimmed_at_first_separator_mixed_separators() {
+        let file_name = OsStr::new("myapp-1.2_linux.amd64");
+        let result = get_stem_name_trimmed_at_first_separator(file_name);
+        // Should stop at the first separator it finds (hyphen in this case)
+        assert_eq!(result, OsString::from("myapp"));
+    }
+
+    #[test]
+    fn test_get_stem_name_trimmed_at_first_separator_no_separators() {
+        let file_name = OsStr::new("myapp");
+        let result = get_stem_name_trimmed_at_first_separator(file_name);
+        assert_eq!(result, OsString::from("myapp"));
+    }
+
+    #[test]
+    fn test_get_stem_name_trimmed_at_first_separator_with_trailing_digits() {
+        let file_name = OsStr::new("myapp123_version");
+        let result = get_stem_name_trimmed_at_first_separator(file_name);
+        assert_eq!(result, OsString::from("myapp"));
+    }
+
+    #[test]
+    fn test_get_stem_name_trimmed_at_first_separator_only_digits_after_separator() {
+        let file_name = OsStr::new("myapp_123456");
+        let result = get_stem_name_trimmed_at_first_separator(file_name);
+        assert_eq!(result, OsString::from("myapp"));
+    }
+
+    #[test]
+    fn test_get_stem_name_trimmed_at_first_separator_digits_in_name() {
+        let file_name = OsStr::new("my2app_version");
+        let result = get_stem_name_trimmed_at_first_separator(file_name);
+        // Digits in the middle should be preserved, only trailing digits are trimmed
+        assert_eq!(result, OsString::from("my2app"));
+    }
+
+    #[test]
+    fn test_get_stem_name_trimmed_at_first_separator_empty_string() {
+        let file_name = OsStr::new("");
+        let result = get_stem_name_trimmed_at_first_separator(file_name);
+        assert_eq!(result, OsString::from(""));
+    }
+
+    #[test]
+    fn test_get_stem_name_trimmed_at_first_separator_separator_at_start() {
+        let file_name = OsStr::new("_myapp_version");
+        let result = get_stem_name_trimmed_at_first_separator(file_name);
+        // Should return empty string since separator is at the beginning
+        assert_eq!(result, OsString::from(""));
+    }
+
+    #[test]
+    fn test_get_stem_name_trimmed_at_first_separator_multiple_trailing_digits() {
+        let file_name = OsStr::new("myapp12345_version");
+        let result = get_stem_name_trimmed_at_first_separator(file_name);
+        assert_eq!(result, OsString::from("myapp"));
+    }
+
+    #[test]
+    fn test_get_stem_name_trimmed_at_first_separator_real_world_examples() {
+        // Test with real-world binary names
+        let file_name1 = OsStr::new("ripgrep-13.0.0-x86_64-unknown-linux-musl");
+        let result1 = get_stem_name_trimmed_at_first_separator(file_name1);
+        assert_eq!(result1, OsString::from("ripgrep"));
+
+        let file_name2 = OsStr::new("bat_0.24.0_amd64.deb");
+        let result2 = get_stem_name_trimmed_at_first_separator(file_name2);
+        assert_eq!(result2, OsString::from("bat"));
+
+        let file_name3 = OsStr::new("fd-v8.7.0-x86_64-unknown-linux-gnu.tar.gz");
+        let result3 = get_stem_name_trimmed_at_first_separator(file_name3);
+        assert_eq!(result3, OsString::from("fd"));
+    }
+
+    #[test]
+    fn test_get_stem_name_trimmed_at_first_separator_unicode() {
+        let file_name = OsStr::new("myapp_测试_version");
+        let result = get_stem_name_trimmed_at_first_separator(file_name);
+        assert_eq!(result, OsString::from("myapp"));
+    }
+
+    #[test]
+    fn test_get_stem_name_trimmed_at_first_separator_only_separators() {
+        let file_name = OsStr::new("___");
+        let result = get_stem_name_trimmed_at_first_separator(file_name);
+        assert_eq!(result, OsString::from(""));
+    }
 }

--- a/src/files/utils.rs
+++ b/src/files/utils.rs
@@ -1,3 +1,4 @@
+use crate::constants::SUPPORTED_EXTENSIONS;
 use std::path::Path;
 
 pub fn get_file_extension(archive_path: &Path) -> &str {
@@ -27,4 +28,16 @@ pub fn get_file_name(archive_path: &Path) -> &str {
         .file_name()
         .and_then(|f| f.to_str())
         .unwrap_or_default()
+}
+
+pub fn strip_supported_extensions(path: &Path) -> &str {
+    let filename = get_file_name(path);
+    SUPPORTED_EXTENSIONS
+        .iter()
+        .find_map(|ext| filename.strip_suffix(ext))
+        .unwrap_or_else(|| {
+            path.file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or(filename)
+        })
 }


### PR DESCRIPTION
now, apart from binaries that are archived, we support installation of those
single binary assets that are not archived or compressed.

- **refactor: move function to proper module**
- **refactor: move magic number func to proper file**
- **refactor: using Path instead of PathBuf**
- **refactor: slightly easier to read logic**
- **feat: handle installation of non-archived executables**
- **feat: handle uncompressed executables with arch or version in filename**
