### PR TITLE
feat: new `which` command to know which repository provides a binary

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -128,6 +128,14 @@ pub struct UnlinkArgs {
     pub yes: bool,
 }
 
+// Structure for the which command
+#[derive(Parser, Clone)]
+pub struct WhichArgs {
+    /// Name of the binary to look up
+    #[arg(required = true, value_parser = validate_binary_name)]
+    pub binary_name: String,
+}
+
 // Structure for the uninstall command
 #[derive(Parser, Clone)]
 #[command(group(ArgGroup::new("what_to_uninstall").required(true).args(["version", "all"])))]
@@ -160,6 +168,9 @@ pub enum Cmd {
 
     /// List all installed binaries and their versions
     List,
+
+    /// Show which repository provides a binary
+    Which(WhichArgs),
 
     /// Set an installed version of a slug as the default one
     Use(UseArgs),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -11,3 +11,4 @@ pub mod make_default;
 pub mod uninstall;
 pub mod unlink;
 pub mod update;
+pub mod which;

--- a/src/commands/which.rs
+++ b/src/commands/which.rs
@@ -1,0 +1,103 @@
+//! Main file handling 'which' command
+
+use anyhow::{bail, Context, Result};
+use log::{debug, info};
+use std::path::Path;
+
+use crate::cli::WhichArgs;
+use crate::files::datadirs;
+use crate::models::slug::Slug;
+
+pub fn run_which(args: &WhichArgs) -> Result<()> {
+    let bin_dir = datadirs::get_bin_dir().context("Cannot get bin directory path")?;
+    let binary_path = bin_dir.join(&args.binary_name);
+
+    // Check if binary exists
+    if !binary_path.exists() {
+        info!("'{}' not found in poof's bin directory.", args.binary_name);
+        return Ok(());
+    }
+
+    // Try to read the symlink
+    let symlink_target = match binary_path.read_link() {
+        Ok(target) => target,
+        Err(_) => {
+            info!(
+                "'{}' exists in poof's bin directory but is not a symlink.\n\
+                This is likely a foreign binary not managed by poof. Please remove it and try again.",
+                args.binary_name
+            );
+            return Ok(());
+        }
+    };
+
+    // Extract the slug from the symlink target path
+    let (slug, version) = extract_slug_from_path(&symlink_target).with_context(|| {
+        format!(
+            "Cannot determine repository providing '{}'.",
+            args.binary_name
+        )
+    })?;
+
+    info!(
+        "{} is provided by '{}' version {}.",
+        args.binary_name, slug, version
+    );
+
+    Ok(())
+}
+
+/// Extract the repository slug (username/reponame) from a binary path.
+/// The path is expected to be in the format:
+/// ...data_dir/SERVER_NAME/USERNAME/REPO_NAME/VERSION/binary_name
+fn extract_slug_from_path(path: &Path) -> Result<(String, String)> {
+    let path_str = path.to_string_lossy();
+
+    // Find the data dir part and extract what comes after.
+    // IMPORTANT: Do NOT rely on any platform-specific path for data directory.
+    //            Instead, start from the data subdirectory, which is always the same.
+    let marker = "poof/data/";
+    if let Some(pos) = path_str.find(marker) {
+        let after_data_dir = &path_str[pos + marker.len()..];
+
+        // Split by path separator and take the first two components (username/reponame)
+        let components: Vec<&str> = after_data_dir
+            .split(std::path::MAIN_SEPARATOR)
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        // The path is expected to be in the format:
+        // ...data_dir/SERVER_NAME/USERNAME/REPO_NAME/VERSION/binary_name
+        if components.len() == 5 {
+            return Ok((
+                Slug::from_parts(components[1], components[2]).map(|slug| slug.to_string())?,
+                components[3].to_string(),
+            ));
+        }
+        bail!("Internal error");
+    }
+
+    debug!(
+        "Cannot determine repository providing '{}'.",
+        path.to_string_lossy()
+    );
+    bail!("Internal error");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_slug_from_path() {
+        // note: no need to make this cross-platform since the implementation
+        // does not rely on any platform-specific functionality and it starts from
+        // data subdirectory wherever it is located.
+        let path = Path::new(
+            "/home/user/.local/share/poof/data/github.com/username/reponame/1.0.0/binary_name",
+        );
+        let (slug, version) = extract_slug_from_path(path).unwrap();
+        assert_eq!(slug, "username/reponame");
+        assert_eq!(version, "1.0.0");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,6 +114,9 @@ fn run() -> Result<()> {
                 drop(stdout); // explicitly release the lock
             }
         }
+        Cmd::Which(args) => {
+            commands::which::run_which(args)?;
+        }
         Cmd::Update(args) => {
             commands::update::process_update(args)?; // we use ? here, it returns a Result
         }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -39,3 +39,5 @@ mod unlink;
 mod update;
 #[path = "integration/commands/use.rs"]
 mod r#use;
+#[path = "integration/commands/which.rs"]
+mod which;

--- a/tests/integration/commands/which.rs
+++ b/tests/integration/commands/which.rs
@@ -1,0 +1,323 @@
+//! Integration tests for the 'which' command
+
+use assert_cmd::cargo;
+use serial_test::serial;
+use std::process::Command;
+
+// Common module is included from the parent integration.rs file
+use super::common::fixtures::test_env::TestFixture;
+use super::common::helpers::set_test_env;
+
+/// Helper function to create a managed symlink for testing
+/// Creates a fake installation and symlinks a binary from it to bin_dir
+#[cfg(not(target_os = "windows"))]
+fn create_managed_symlink(
+    fixture: &TestFixture,
+    binary_name: &str,
+    repo: &str,
+    version: &str,
+) -> Result<std::path::PathBuf, Box<dyn std::error::Error>> {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+
+    // Create fake installation
+    let install_dir = fixture.create_fake_installation(repo, version)?;
+
+    // The installation creates a binary with the repo name (last part)
+    // We need to find what binary was created or use the provided name
+    let repo_binary_name = repo.split('/').next_back().unwrap_or(binary_name);
+    let binary_in_install = install_dir.join(repo_binary_name);
+
+    // If the binary doesn't exist, create it with the provided name
+    if !binary_in_install.exists() {
+        // Create a new binary with the desired name
+        fs::write(
+            install_dir.join(binary_name),
+            b"#!/bin/sh\necho 'test binary'",
+        )?;
+        let mut perms = fs::metadata(install_dir.join(binary_name))?.permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(install_dir.join(binary_name), perms)?;
+    }
+
+    // Create symlink in bin_dir
+    let source = if binary_in_install.exists() {
+        binary_in_install
+    } else {
+        install_dir.join(binary_name)
+    };
+    let symlink_path = fixture.bin_dir.join(binary_name);
+    std::os::unix::fs::symlink(&source, &symlink_path)?;
+
+    Ok(symlink_path)
+}
+
+// ============================================================================
+// Basic Validation Tests
+// ============================================================================
+
+#[serial]
+#[test]
+fn test_which_requires_binary_name() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::new(cargo::cargo_bin!("poof"));
+    cmd.arg("which");
+
+    let output = cmd.output()?;
+
+    assert!(
+        !output.status.success(),
+        "Command should fail without binary name"
+    );
+
+    Ok(())
+}
+
+// ============================================================================
+// Non-existent Binary Tests
+// ============================================================================
+
+#[serial]
+#[test]
+fn test_which_nonexistent_binary() -> Result<(), Box<dyn std::error::Error>> {
+    let fixture = TestFixture::new()?;
+
+    let mut cmd = Command::new(cargo::cargo_bin!("poof"));
+    cmd.arg("which").arg("nonexistent_binary");
+    set_test_env(&mut cmd, &fixture);
+    let output = cmd.output()?;
+
+    assert!(
+        output.status.success(),
+        "Command should succeed even when binary doesn't exist"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not found"),
+        "Output should indicate binary not found: {}",
+        stderr
+    );
+
+    Ok(())
+}
+
+// ============================================================================
+// Successful Lookup Tests
+// ============================================================================
+
+#[serial]
+#[test]
+#[cfg(not(target_os = "windows"))]
+fn test_which_with_valid_symlink() -> Result<(), Box<dyn std::error::Error>> {
+    let fixture = TestFixture::new()?;
+    let binary_name = "mybin";
+    let repo = "someuser/somerepo";
+    let version = "2.5.3";
+
+    let symlink_path = create_managed_symlink(&fixture, binary_name, repo, version)?;
+
+    assert!(symlink_path.exists(), "Symlink should exist");
+
+    let mut cmd = Command::new(cargo::cargo_bin!("poof"));
+    cmd.arg("which").arg(binary_name);
+    set_test_env(&mut cmd, &fixture);
+    let output = cmd.output()?;
+
+    assert!(output.status.success(), "Command should succeed");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // Should show the slug (username/reponame)
+    assert!(
+        stderr.contains("someuser/somerepo"),
+        "Output should contain the repository slug: {}",
+        stderr
+    );
+
+    // Should also show version information
+    assert!(
+        stderr.contains("2.5.3") || stderr.contains("version"),
+        "Output should contain version information: {}",
+        stderr
+    );
+
+    Ok(())
+}
+
+// ============================================================================
+// Non-Symlink Binary Tests
+// ============================================================================
+
+#[serial]
+#[test]
+fn test_which_regular_file_not_symlink() -> Result<(), Box<dyn std::error::Error>> {
+    use std::fs;
+
+    let fixture = TestFixture::new()?;
+    let binary_name = "regular_file";
+    let file_path = fixture.bin_dir.join(binary_name);
+
+    // Create a regular file (not a symlink)
+    fs::write(&file_path, b"#!/bin/sh\necho 'regular file'")?;
+
+    assert!(file_path.exists(), "File should exist");
+
+    let mut cmd = Command::new(cargo::cargo_bin!("poof"));
+    cmd.arg("which").arg(binary_name);
+    set_test_env(&mut cmd, &fixture);
+    let output = cmd.output()?;
+
+    assert!(
+        output.status.success(),
+        "Command should succeed but indicate it's not managed"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not a symlink") || stderr.contains("foreign binary"),
+        "Output should indicate binary is not a symlink or is foreign: {}",
+        stderr
+    );
+
+    Ok(())
+}
+
+// ============================================================================
+// Edge Cases
+// ============================================================================
+
+#[serial]
+#[test]
+#[cfg(not(target_os = "windows"))]
+fn test_which_broken_symlink() -> Result<(), Box<dyn std::error::Error>> {
+    let fixture = TestFixture::new()?;
+    let binary_name = "broken_link";
+    let symlink_path = fixture.bin_dir.join(binary_name);
+
+    // Create a symlink pointing to a non-existent target within the data directory
+    // This simulates a broken poof-managed binary
+    let nonexistent_target = fixture
+        .data_dir
+        .join("github.com")
+        .join("user")
+        .join("repo")
+        .join("1.0.0")
+        .join("binary");
+    std::os::unix::fs::symlink(&nonexistent_target, &symlink_path)?;
+
+    // Verify the symlink metadata exists (even though target doesn't)
+    assert!(
+        symlink_path.symlink_metadata().is_ok(),
+        "Symlink should exist (even if broken)"
+    );
+
+    let mut cmd = Command::new(cargo::cargo_bin!("poof"));
+    cmd.arg("which").arg(binary_name);
+    set_test_env(&mut cmd, &fixture);
+    let output = cmd.output()?;
+
+    // The command will report "not found" because .exists() returns false for broken symlinks
+    // This is actually correct behavior - a broken symlink is effectively not usable
+    assert!(
+        output.status.success(),
+        "Command should succeed even with broken symlink"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not found"),
+        "Should indicate binary not found for broken symlink: {}",
+        stderr
+    );
+
+    Ok(())
+}
+
+#[serial]
+#[test]
+#[cfg(not(target_os = "windows"))]
+fn test_which_symlink_outside_data_dir() -> Result<(), Box<dyn std::error::Error>> {
+    use std::fs;
+
+    let fixture = TestFixture::new()?;
+    let binary_name = "foreign_binary";
+    let symlink_path = fixture.bin_dir.join(binary_name);
+
+    // Create a target outside the data directory
+    let external_target = fixture.home_dir.join("external_bin");
+    fs::write(&external_target, b"#!/bin/sh\necho 'external'")?;
+
+    // Create symlink pointing to external target
+    std::os::unix::fs::symlink(&external_target, &symlink_path)?;
+
+    assert!(symlink_path.exists(), "Symlink should exist");
+
+    let mut cmd = Command::new(cargo::cargo_bin!("poof"));
+    cmd.arg("which").arg(binary_name);
+    set_test_env(&mut cmd, &fixture);
+    let output = cmd.output()?;
+
+    // The command should fail or return an error for external binaries
+    // since the implementation bails when it can't extract the slug
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // Either the command fails or shows an error message
+    assert!(
+        !output.status.success()
+            || stderr.contains("Cannot determine")
+            || stderr.contains("Internal error"),
+        "Should indicate error for external binary. stderr: {}, exit: {}",
+        stderr,
+        output.status
+    );
+
+    Ok(())
+}
+
+#[serial]
+#[test]
+#[cfg(not(target_os = "windows"))]
+fn test_which_output_format() -> Result<(), Box<dyn std::error::Error>> {
+    let fixture = TestFixture::new()?;
+    let binary_name = "testbin";
+    let repo = "user/repo";
+    let version = "1.0.1";
+
+    create_managed_symlink(&fixture, binary_name, repo, version)?;
+
+    let mut cmd = Command::new(cargo::cargo_bin!("poof"));
+    cmd.arg("which").arg(binary_name);
+    set_test_env(&mut cmd, &fixture);
+    let output = cmd.output()?;
+
+    assert!(output.status.success(), "Command should succeed");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    // Check output format matches expected pattern
+    assert!(
+        stderr.contains("is provided by"),
+        "Output should contain 'is provided by': {}",
+        stderr
+    );
+
+    assert!(
+        stderr.contains(binary_name),
+        "Output should contain binary name: {}",
+        stderr
+    );
+
+    assert!(
+        stderr.contains("user/repo"),
+        "Output should contain the repository slug: {}",
+        stderr
+    );
+
+    assert!(
+        stderr.contains("version") || stderr.contains("1.0.1"),
+        "Output should contain version information: {}",
+        stderr
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
This pull request introduces a new `which` command to the CLI, allowing users to determine which repository and version provide a given binary managed by the tool. It includes the implementation of the command, integration into the CLI, and a comprehensive suite of integration tests covering various scenarios and edge cases.

**New Feature: `which` Command**

* Added the `WhichArgs` struct and the `Which` variant to the `Cmd` enum in `src/cli.rs` to support the new `which` command, allowing users to look up the source repository and version for a managed binary.

**Integration and Wiring**

* Registered the new command in the CLI command dispatcher in `src/main.rs` and the module system in `src/commands/mod.rs`.

**Testing**

* Added a new integration test module `tests/integration/commands/which.rs` with comprehensive tests for the `which` command, covering:
  * Required arguments and error handling,
  * Lookup of managed binaries,
  * Handling of non-existent binaries, regular files, broken symlinks, and symlinks outside the managed data directory,
  * Output format validation.
* Registered the test module in the integration test suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `which` command to identify which repository provides a specific binary.
  * Display repository and version information for managed binaries.
  * Includes error handling for missing binaries, regular files, and invalid paths.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->