### PR TITLE
feat: new `what` command to know what binaries a slug provides

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -136,6 +136,15 @@ pub struct WhichArgs {
     pub binary_name: String,
 }
 
+// Structure for the what command
+#[derive(Parser, Clone)]
+pub struct WhatArgs {
+    /// GitHub user and repository in the format USERNAME/REPO
+    /// e.g. pirafrank/rust_exif_renamer
+    #[arg(required = true, value_parser = validate_repo_format)]
+    pub repo: String,
+}
+
 // Structure for the uninstall command
 #[derive(Parser, Clone)]
 #[command(group(ArgGroup::new("what_to_uninstall").required(true).args(["version", "all"])))]
@@ -171,6 +180,9 @@ pub enum Cmd {
 
     /// Show which repository provides a binary
     Which(WhichArgs),
+
+    /// List all binaries provided by the latest version of a repository
+    What(WhatArgs),
 
     /// Set an installed version of a slug as the default one
     Use(UseArgs),

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -11,4 +11,5 @@ pub mod make_default;
 pub mod uninstall;
 pub mod unlink;
 pub mod update;
+pub mod what;
 pub mod which;

--- a/src/commands/what.rs
+++ b/src/commands/what.rs
@@ -1,0 +1,95 @@
+//! Main file handling 'what' command
+
+use anyhow::{bail, Context, Result};
+use log::{error, info};
+use std::fs;
+
+use crate::cli::WhatArgs;
+use crate::files::datadirs;
+use crate::files::filesys;
+use crate::files::utils::find_similar_repo;
+use crate::models::slug::Slug;
+use crate::utils::semver::SemverSort;
+
+pub fn run_what(args: &WhatArgs) -> Result<()> {
+    // Validate slug
+    let slug = Slug::new(&args.repo)?;
+
+    // Get data directory
+    let data_dir = datadirs::get_data_dir().context("Cannot get data directory path")?;
+
+    // Build path to slug's versions directory
+    let versions_dir = datadirs::get_versions_nest(&data_dir, slug.as_str());
+
+    // Check if the slug is installed
+    if !versions_dir.exists() {
+        if let Some(similar_repo) = find_similar_repo(&data_dir, slug.as_str()) {
+            error!(
+                "It looks like '{}' is not installed. Did you mean: {}",
+                slug, similar_repo
+            );
+        } else {
+            error!("It looks like '{}' is not installed. Typo?", slug);
+        }
+        error!("Check installed binaries using 'list' command.");
+        bail!("Repository '{}' not found", slug);
+    }
+
+    // Read all version subdirectories
+    let entries = fs::read_dir(&versions_dir)
+        .with_context(|| format!("Cannot read versions directory for '{}'", slug))?;
+
+    let mut versions: Vec<String> = Vec::new();
+    for entry in entries.flatten() {
+        if let Ok(file_type) = entry.file_type() {
+            if file_type.is_dir() {
+                if let Some(version_name) = entry.file_name().to_str() {
+                    versions.push(version_name.to_string());
+                }
+            }
+        }
+    }
+
+    // Check if any versions were found
+    if versions.is_empty() {
+        error!(
+            "No versions found for '{}'. Installation may be corrupted.",
+            slug
+        );
+        bail!("No versions found for '{}'", slug);
+    }
+
+    // Sort versions using semantic versioning
+    versions.sort_semver();
+
+    // Get the latest version (last element after sorting)
+    let latest_version = versions
+        .last()
+        .expect("versions is non-empty after check")
+        .clone();
+
+    // Build path to latest version directory
+    let latest_version_dir = datadirs::get_binary_nest(&data_dir, slug.as_str(), &latest_version);
+
+    // Find all executables in the latest version directory
+    let binaries = filesys::find_exec_files_in_dir(&latest_version_dir);
+
+    // Check if any binaries were found
+    if binaries.is_empty() {
+        error!(
+            "No binaries found in version {} of '{}'. Installation may be corrupted.",
+            latest_version, slug
+        );
+        bail!("No binaries found for '{}'", slug);
+    }
+
+    // Output the results
+    info!("{} (version {}) provides:", slug, latest_version);
+    for binary_path in binaries {
+        if let Some(binary_name) = binary_path.file_name() {
+            info!("- {}", binary_name.to_string_lossy());
+        }
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -117,6 +117,9 @@ fn run() -> Result<()> {
         Cmd::Which(args) => {
             commands::which::run_which(args)?;
         }
+        Cmd::What(args) => {
+            commands::what::run_what(args)?;
+        }
         Cmd::Update(args) => {
             commands::update::process_update(args)?; // we use ? here, it returns a Result
         }

--- a/tests/common/helpers.rs
+++ b/tests/common/helpers.rs
@@ -50,3 +50,12 @@ pub fn assert_contains_all(text: &str, substrings: &[&str]) {
         );
     }
 }
+
+/// Helper to make a file executable on Unix-like systems
+pub fn make_executable(path: &std::path::Path) -> std::io::Result<()> {
+    use std::fs;
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = fs::metadata(path)?.permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms)
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -39,5 +39,7 @@ mod unlink;
 mod update;
 #[path = "integration/commands/use.rs"]
 mod r#use;
+#[path = "integration/commands/what.rs"]
+mod what;
 #[path = "integration/commands/which.rs"]
 mod which;

--- a/tests/integration/commands/what.rs
+++ b/tests/integration/commands/what.rs
@@ -1,0 +1,349 @@
+//! Integration tests for the 'what' command
+
+use assert_cmd::cargo;
+use serial_test::serial;
+use std::process::Command;
+
+use crate::common::helpers::make_executable;
+
+// Common module is included from the parent integration.rs file
+use super::common::fixtures::test_env::TestFixture;
+use super::common::helpers::set_test_env;
+
+// ============================================================================
+// Basic Validation Tests
+// ============================================================================
+
+#[serial]
+#[test]
+fn test_what_requires_repo_slug() -> Result<(), Box<dyn std::error::Error>> {
+    let fixture = TestFixture::new()?;
+
+    let mut cmd = Command::new(cargo::cargo_bin!("poof"));
+    cmd.arg("what");
+    set_test_env(&mut cmd, &fixture);
+
+    let output = cmd.output()?;
+
+    assert!(
+        !output.status.success(),
+        "Command should fail without repo slug"
+    );
+
+    Ok(())
+}
+
+#[serial]
+#[test]
+fn test_what_invalid_slug_format() -> Result<(), Box<dyn std::error::Error>> {
+    let fixture = TestFixture::new()?;
+
+    // Test with invalid slug format (no slash)
+    let mut cmd = Command::new(cargo::cargo_bin!("poof"));
+    cmd.arg("what").arg("invalidslug");
+    set_test_env(&mut cmd, &fixture);
+
+    let output = cmd.output()?;
+
+    assert!(
+        !output.status.success(),
+        "Command should fail with invalid slug format"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("USERNAME/REPO") || stderr.contains("format"),
+        "Error should mention correct format: {}",
+        stderr
+    );
+
+    Ok(())
+}
+
+// ============================================================================
+// Non-existent Repository Tests
+// ============================================================================
+
+#[serial]
+#[test]
+fn test_what_nonexistent_slug() -> Result<(), Box<dyn std::error::Error>> {
+    let fixture = TestFixture::new()?;
+
+    let mut cmd = Command::new(cargo::cargo_bin!("poof"));
+    cmd.arg("what").arg("nonexistent/repo");
+    set_test_env(&mut cmd, &fixture);
+
+    let output = cmd.output()?;
+
+    assert!(
+        !output.status.success(),
+        "Command should fail when repository doesn't exist"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not installed"),
+        "Output should indicate repository not installed: {}",
+        stderr
+    );
+
+    Ok(())
+}
+
+#[serial]
+#[test]
+#[cfg(not(target_os = "windows"))]
+fn test_what_fuzzy_match_suggestion() -> Result<(), Box<dyn std::error::Error>> {
+    let fixture = TestFixture::new()?;
+
+    // Create a fake installation for a similar repo
+    fixture.create_fake_installation("testuser/testrepo", "1.0.0")?;
+
+    // Try to query a similar but incorrect repo name
+    let mut cmd = Command::new(cargo::cargo_bin!("poof"));
+    cmd.arg("what").arg("testuser/testrepoo"); // Note the extra 'o'
+    set_test_env(&mut cmd, &fixture);
+
+    let output = cmd.output()?;
+
+    assert!(
+        !output.status.success(),
+        "Command should fail when repository doesn't exist"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Did you mean") || stderr.contains("testuser/testrepo"),
+        "Output should suggest similar repository: {}",
+        stderr
+    );
+
+    Ok(())
+}
+
+// ============================================================================
+// Single Version Tests
+// ============================================================================
+
+#[serial]
+#[test]
+#[cfg(not(target_os = "windows"))]
+fn test_what_single_version_single_binary() -> Result<(), Box<dyn std::error::Error>> {
+    let fixture = TestFixture::new()?;
+
+    // Create a fake installation with one version and one binary
+    let install_dir = fixture.create_fake_installation("testuser/mytool", "1.0.0")?;
+
+    // Verify the binary was created
+    assert!(install_dir.join("mytool").exists());
+
+    let mut cmd = Command::new(cargo::cargo_bin!("poof"));
+    cmd.arg("what").arg("testuser/mytool");
+    set_test_env(&mut cmd, &fixture);
+
+    let output = cmd.output()?;
+
+    assert!(
+        output.status.success(),
+        "Command should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("testuser/mytool"),
+        "Output should show slug: {}",
+        stderr
+    );
+    assert!(
+        stderr.contains("1.0.0"),
+        "Output should show version: {}",
+        stderr
+    );
+    assert!(
+        stderr.contains("mytool"),
+        "Output should list the binary: {}",
+        stderr
+    );
+
+    Ok(())
+}
+
+// ============================================================================
+// Multiple Version Tests
+// ============================================================================
+
+#[serial]
+#[test]
+#[cfg(not(target_os = "windows"))]
+fn test_what_multiple_versions_latest_selected() -> Result<(), Box<dyn std::error::Error>> {
+    let fixture = TestFixture::new()?;
+
+    // Create multiple versions
+    fixture.create_fake_installation("testuser/multiver", "1.0.0")?;
+    fixture.create_fake_installation("testuser/multiver", "2.1.0")?;
+    fixture.create_fake_installation("testuser/multiver", "1.5.0")?;
+    fixture.create_fake_installation("testuser/multiver", "2.0.0")?;
+
+    let mut cmd = Command::new(cargo::cargo_bin!("poof"));
+    cmd.arg("what").arg("testuser/multiver");
+    set_test_env(&mut cmd, &fixture);
+
+    let output = cmd.output()?;
+
+    assert!(
+        output.status.success(),
+        "Command should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("2.1.0"),
+        "Output should show latest version (2.1.0): {}",
+        stderr
+    );
+    assert!(
+        !stderr.contains("1.0.0") && !stderr.contains("1.5.0") && !stderr.contains("2.0.0"),
+        "Output should not show older versions: {}",
+        stderr
+    );
+
+    Ok(())
+}
+
+// ============================================================================
+// Multiple Binary Tests
+// ============================================================================
+
+#[serial]
+#[test]
+#[cfg(not(target_os = "windows"))]
+fn test_what_latest_version_multiple_binaries() -> Result<(), Box<dyn std::error::Error>> {
+    use std::fs;
+
+    let fixture = TestFixture::new()?;
+
+    // Create a fake installation with multiple binaries
+    let install_dir = fixture.create_fake_installation("testuser/multibin", "1.0.0")?;
+
+    // The create_fake_installation already creates one binary named "multibin"
+    // Let's add more binaries
+    let binary2_path = install_dir.join("tool1");
+    let binary3_path = install_dir.join("tool2");
+
+    fs::write(&binary2_path, b"#!/bin/sh\necho 'tool1'")?;
+    fs::write(&binary3_path, b"#!/bin/sh\necho 'tool2'")?;
+
+    // Make them executable
+    make_executable(&binary2_path)?;
+    make_executable(&binary3_path)?;
+
+    let mut cmd = Command::new(cargo::cargo_bin!("poof"));
+    cmd.arg("what").arg("testuser/multibin");
+    set_test_env(&mut cmd, &fixture);
+
+    let output = cmd.output()?;
+
+    assert!(
+        output.status.success(),
+        "Command should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("multibin"),
+        "Output should list first binary: {}",
+        stderr
+    );
+    assert!(
+        stderr.contains("tool1"),
+        "Output should list second binary: {}",
+        stderr
+    );
+    assert!(
+        stderr.contains("tool2"),
+        "Output should list third binary: {}",
+        stderr
+    );
+
+    Ok(())
+}
+
+// ============================================================================
+// Semantic Versioning Tests
+// ============================================================================
+
+#[serial]
+#[test]
+#[cfg(not(target_os = "windows"))]
+fn test_what_semantic_version_sorting() -> Result<(), Box<dyn std::error::Error>> {
+    let fixture = TestFixture::new()?;
+
+    // Create versions that test semantic versioning
+    fixture.create_fake_installation("testuser/semver", "1.0.0")?;
+    fixture.create_fake_installation("testuser/semver", "1.10.0")?;
+    fixture.create_fake_installation("testuser/semver", "1.2.0")?;
+    fixture.create_fake_installation("testuser/semver", "2.0.0")?;
+    fixture.create_fake_installation("testuser/semver", "1.9.0")?;
+
+    let mut cmd = Command::new(cargo::cargo_bin!("poof"));
+    cmd.arg("what").arg("testuser/semver");
+    set_test_env(&mut cmd, &fixture);
+
+    let output = cmd.output()?;
+
+    assert!(
+        output.status.success(),
+        "Command should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("2.0.0"),
+        "Output should show latest version (2.0.0), not 1.10.0 or other versions: {}",
+        stderr
+    );
+
+    Ok(())
+}
+
+// ============================================================================
+// Edge Case Tests
+// ============================================================================
+
+#[serial]
+#[test]
+#[cfg(not(target_os = "windows"))]
+fn test_what_prerelease_versions() -> Result<(), Box<dyn std::error::Error>> {
+    let fixture = TestFixture::new()?;
+
+    // Create versions with prerelease tags
+    fixture.create_fake_installation("testuser/prerelease", "1.0.0")?;
+    fixture.create_fake_installation("testuser/prerelease", "2.0.0-alpha")?;
+    fixture.create_fake_installation("testuser/prerelease", "2.0.0-beta")?;
+    fixture.create_fake_installation("testuser/prerelease", "2.0.0")?;
+
+    let mut cmd = Command::new(cargo::cargo_bin!("poof"));
+    cmd.arg("what").arg("testuser/prerelease");
+    set_test_env(&mut cmd, &fixture);
+
+    let output = cmd.output()?;
+
+    assert!(
+        output.status.success(),
+        "Command should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("2.0.0") && !stderr.contains("alpha") && !stderr.contains("beta"),
+        "Output should show stable 2.0.0, not prerelease versions: {}",
+        stderr
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
This pull request introduces a new `what` command to the CLI tool, allowing users to list all binaries provided by the latest version of a specified repository. The implementation includes argument parsing, command handling, and comprehensive integration tests to ensure correct behavior across various scenarios.

### New Feature: `what` Command

* Added a new `WhatArgs` struct and updated the `Cmd` enum in `src/cli.rs` to support the `what` command, which takes a repository slug and lists binaries from its latest installed version.
* Implemented the main logic for the `what` command in `src/commands/what.rs`, including validation, semantic version sorting, fuzzy matching for similar repo names, and error handling for missing or corrupted installations.
* Registered the new module in `src/commands/mod.rs` and integrated the command handler in `src/main.rs`.

### Testing and Utilities

* Added comprehensive integration tests for the `what` command in `tests/integration/commands/what.rs`, covering argument validation, non-existent repositories, multiple versions, multiple binaries, semantic version sorting, and edge cases like prerelease versions.
* Introduced a helper function `make_executable` in `tests/common/helpers.rs` to facilitate test setup for Unix-like systems.
* Registered the new test module in `tests/integration.rs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `what` CLI command to report the latest installed version and list available binaries for a USERNAME/REPO identifier; validates repo format and suggests similar names when not found.

* **Tests**
  * Comprehensive integration tests covering input validation, non-existent repos, version selection (including semver/prerelease rules), binary discovery, and multi-version scenarios.
  * Added a test helper to mark files executable for Unix-like test fixtures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->