### PR TITLE
feat!: removed `update --self` option for poof update in favor of other install methods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1408,7 +1408,6 @@ dependencies = [
  "regex",
  "reqwest",
  "ron",
- "self-replace",
  "semver",
  "serde",
  "serde_json",
@@ -1850,17 +1849,6 @@ name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
-
-[[package]]
-name = "self-replace"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7"
-dependencies = [
- "fastrand",
- "tempfile",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "semver"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,6 @@ regex = "1.11.1"
 rayon = "1.11.0"
 semver = "1.0.26"
 anyhow = "1.0"
-self-replace = "1.5.0"
 which = "8.0.0"
 
 [dev-dependencies]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -65,18 +65,12 @@ pub struct CmdArgs {
 #[derive(Parser, Clone)]
 pub struct UpdateArgs {
     /// Github slug in the format USERNAME/REPO
-    #[arg(value_parser = validate_repo_format, required_unless_present_any = ["all", "update_self"])]
+    #[arg(value_parser = validate_repo_format, required_unless_present_any = ["all"])]
     pub repo: Option<String>,
 
     /// Update all installed binaries
-    #[arg(long, conflicts_with_all = ["repo", "update_self"])]
+    #[arg(long, conflicts_with_all = ["repo"])]
     pub all: bool,
-
-    /// Update poof itself to the latest version.
-    /// It works only if the binary has not been installed from a package manager.
-    /// If you installed poof from a package manager, update via that package manager instead.
-    #[arg(long = "self", conflicts_with_all = ["repo", "all"])]
-    pub update_self: bool,
 }
 
 fn parse_shell(s: &str) -> Result<SupportedShell, String> {

--- a/tests/common/fixtures/README.md
+++ b/tests/common/fixtures/README.md
@@ -27,12 +27,16 @@ use super::common::fixtures::mock_github::MockGitHub;
 let mut mock_github = MockGitHub::new();
 
 // Mock up-to-date response
-let _m = mock_github.mock_poof_update_get_version("v1.0.0");
+let _m = mock_github.mock_latest_release(
+    "testuser/testrepo",
+    "v1.0.0",
+    vec![/* assets */]
+);
 
 // Run command with mock API URL
 let output = cmd
-    .arg("update")
-    .arg("--self")
+    .arg("install")
+    .arg("testuser/testrepo")
     .env("POOF_GITHUB_API_URL", mock_github.base_url())
     .output()?;
 ```
@@ -43,7 +47,6 @@ let output = cmd
 - `mock_release_by_tag(repo, tag, assets)` - Mock a specific release by tag
 - `mock_not_found(repo)` - Mock a 404 response
 - `mock_network_error(repo)` - Mock a 500 error
-- `mock_poof_update_get_version(version)` - Mock poof self-update check returning the given version
 
 ### `POOF_GITHUB_API_URL` env var
 

--- a/tests/common/fixtures/mock_github.rs
+++ b/tests/common/fixtures/mock_github.rs
@@ -4,21 +4,12 @@ use mockito::{Matcher, Mock, ServerGuard};
 use serde_json::json;
 
 /// Helper to create a mock GitHub API server
+#[allow(dead_code)]
 pub struct MockGitHub {
     pub server: ServerGuard,
 }
 
-fn get_asset_name_for_current_target() -> String {
-    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
-    return "poof-linux-x86_64".to_string();
-    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
-    return "poof-linux-aarch64".to_string();
-    #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
-    return "poof-darwin-x86_64".to_string();
-    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
-    return "poof-darwin-aarch64".to_string();
-}
-
+#[allow(dead_code)]
 impl MockGitHub {
     /// Create a new mock GitHub API server
     pub fn new() -> Self {
@@ -117,35 +108,17 @@ impl MockGitHub {
             .with_body("Internal Server Error")
             .create()
     }
-
-    /// Mock poof self-update check returning the given version
-    pub fn mock_poof_update_get_version(&mut self, version: &str) -> Mock {
-        let asset_name: String = get_asset_name_for_current_target();
-        let download_url: String = format!(
-            "{}/releases/download/{}/{}",
-            self.base_url(),
-            version,
-            asset_name
-        );
-        self.mock_latest_release(
-            "pirafrank/poof",
-            version,
-            vec![MockAsset {
-                name: asset_name,
-                download_url,
-                content_type: "application/octet-stream".to_string(),
-            }],
-        )
-    }
 }
 
 /// Represents a mock GitHub release asset
+#[allow(dead_code)]
 pub struct MockAsset {
     pub name: String,
     pub download_url: String,
     pub content_type: String,
 }
 
+#[allow(dead_code)]
 impl MockAsset {
     #[allow(dead_code)]
     pub fn new(name: &str, download_url: &str) -> Self {

--- a/tests/integration/commands/update.rs
+++ b/tests/integration/commands/update.rs
@@ -5,7 +5,6 @@ use serial_test::serial;
 use std::process::Command;
 
 // Common module is included from the parent integration.rs file
-use super::common::fixtures::mock_github::MockGitHub;
 use super::common::fixtures::test_env::TestFixture;
 use super::common::helpers::set_test_env;
 use super::common::repo_format_validation::*;
@@ -28,22 +27,6 @@ fn test_update_comprehensive_invalid_repo_formats() -> Result<(), Box<dyn std::e
 #[test]
 fn test_update_comprehensive_valid_repo_formats() -> Result<(), Box<dyn std::error::Error>> {
     test_valid_repo_formats_for_command("update")
-}
-
-#[test]
-fn test_update_all_and_self_conflicting_flags() -> Result<(), Box<dyn std::error::Error>> {
-    // Note: --all and --self don't actually conflict in the current implementation
-    // They both can be used together, though --all takes precedence
-    // This test verifies the command handles both flags gracefully
-    let mut cmd = Command::new(cargo::cargo_bin!("poof"));
-    let output = cmd.arg("update").arg("--all").arg("--self").output()?;
-
-    // Command should fail because --all and --self cannot be used together
-    assert!(
-        !output.status.success(),
-        "Command should fail because --all and --self cannot be used together"
-    );
-    Ok(())
 }
 
 #[test]
@@ -88,132 +71,6 @@ fn test_update_all_flag() -> Result<(), Box<dyn std::error::Error>> {
     assert!(
         !stderr.contains("unexpected argument") && !stderr.contains("unknown flag"),
         "--all flag should be accepted: {}",
-        stderr
-    );
-
-    Ok(())
-}
-
-#[serial]
-#[test]
-fn test_update_self_flag() -> Result<(), Box<dyn std::error::Error>> {
-    // Test that --self flag is accepted
-    let mut cmd = Command::new(cargo::cargo_bin!("poof"));
-    let output = cmd.arg("update").arg("--self").output()?;
-
-    // Should not fail on argument parsing
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        !stderr.contains("unexpected argument") && !stderr.contains("unknown flag"),
-        "--self flag should be accepted: {}",
-        stderr
-    );
-
-    Ok(())
-}
-
-#[serial]
-#[test]
-fn test_update_self_checks_for_updates() -> Result<(), Box<dyn std::error::Error>> {
-    // Test that update --self attempts to check for updates
-    // Uses a mock GitHub API server to avoid network calls
-    let mut mock_github = MockGitHub::new();
-
-    // Mock the response for poof being up-to-date
-    // Use the current version from Cargo.toml
-    let current_version = env!("CARGO_PKG_VERSION");
-    let _m = mock_github.mock_poof_update_get_version(&format!("v{}", current_version));
-
-    let mut cmd = Command::new(cargo::cargo_bin!("poof"));
-    let output = cmd
-        .arg("update")
-        .arg("--self")
-        .env("POOF_GITHUB_API_URL", mock_github.base_url())
-        .output()?;
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    // Should successfully check and report up-to-date status
-    assert!(
-        output.status.success(),
-        "Update --self should succeed when poof is already up-to-date. stdout: {}, stderr: {}",
-        stdout,
-        stderr
-    );
-
-    // Should indicate it's up-to-date (message goes to stderr via logging)
-    assert!(
-        stderr.contains("up-to-date") || stderr.contains(current_version),
-        "Should indicate up-to-date status. stdout: {}, stderr: {}",
-        stdout,
-        stderr
-    );
-
-    Ok(())
-}
-
-#[serial]
-#[test]
-fn test_update_self_newer_version_available() -> Result<(), Box<dyn std::error::Error>> {
-    // Test that update --self detects when a newer version is available
-    // Uses a mock GitHub API server to avoid network calls
-    let mut mock_github = MockGitHub::new();
-
-    // Mock the response with a newer version available
-    let _m = mock_github.mock_poof_update_get_version("v999.999.999");
-
-    let mut cmd = Command::new(cargo::cargo_bin!("poof"));
-    let output = cmd
-        .arg("update")
-        .arg("--self")
-        .env("POOF_GITHUB_API_URL", mock_github.base_url())
-        .output()?;
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    // Should detect newer version
-    // Note: The actual update will fail because we're not providing a real binary,
-    // but it should at least detect the version difference
-    assert!(
-        stdout.contains("Newer version 999.999.999 found")
-            || stderr.contains("Newer version 999.999.999 found"),
-        "Should detect newer version. stdout: {}, stderr: {}",
-        stdout,
-        stderr
-    );
-
-    Ok(())
-}
-
-#[serial]
-#[test]
-fn test_update_self_handles_network_error() -> Result<(), Box<dyn std::error::Error>> {
-    // Test that update --self handles network errors gracefully
-    let mut mock_github = MockGitHub::new();
-
-    // Mock a network error response
-    let _m = mock_github.mock_network_error("pirafrank/poof");
-
-    let mut cmd = Command::new(cargo::cargo_bin!("poof"));
-    let output = cmd
-        .arg("update")
-        .arg("--self")
-        .env("POOF_GITHUB_API_URL", mock_github.base_url())
-        .output()?;
-
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    // Should fail gracefully with an error message
-    assert!(
-        !output.status.success(),
-        "Should fail when GitHub API returns error"
-    );
-
-    assert!(
-        stderr.contains("Failed") || stderr.contains("error") || stderr.contains("Error"),
-        "Should report error gracefully. stderr: {}",
         stderr
     );
 


### PR DESCRIPTION
This pull request removes the self-update (`--self`) feature from the `poof` CLI tool. The main focus is on eliminating all code, tests, documentation, and dependencies related to updating the tool itself. The update command now only supports updating installed repositories, not the CLI binary.

Key changes include:

**Removal of self-update functionality:**
- Removed the `update_self` flag and all related logic from the `UpdateArgs` struct and update command processing in `src/cli.rs` and `src/commands/update.rs`. The update command no longer accepts or handles the `--self` flag. [[1]](diffhunk://#diff-b2812f19576dd53d0c35b107a322f58a00fce6977f4b5976e1961853982af3ccL68-L79) [[2]](diffhunk://#diff-4bf1ef1a8771c506c71d2ef69d5d59e623f54b2cc09f2c297496e30d5f7da25eL159-R162)
- Deleted the entire `update_self` function and all references to it.
- Updated error messages to reflect the absence of the `--self` option.

**Code and dependency cleanup:**
- Removed the `self-replace` crate from dependencies in `Cargo.toml`, as it is no longer needed.
- Cleaned up imports and code in `src/commands/update.rs` that were only used for self-update logic.

**Test and documentation updates:**
- Removed all tests related to self-update from `src/commands/update/tests.rs` and `tests/integration/commands/update.rs`. This includes tests for the `--self` flag, update checks, and error handling. [[1]](diffhunk://#diff-7bbe5c02b1b1fe7ec97cabf4fd9291c4675f86865adc2f54a24d7d58b85e0f75L251-L281) [[2]](diffhunk://#diff-7bbe5c02b1b1fe7ec97cabf4fd9291c4675f86865adc2f54a24d7d58b85e0f75L394-L453) [[3]](diffhunk://#diff-ecd75801b34a83f3aadd7b15ea9ad2fd29a1cb7c1f17e1c2612f0cc6e96f0df5L97-L222)
- Updated test fixtures and documentation to remove references to self-update and related mock helpers in `tests/common/fixtures/README.md` and `tests/common/fixtures/mock_github.rs`. [[1]](diffhunk://#diff-3c90a46c36c3d845d65a410165ecaecd3ee6de6dc843ff34ecd35d1f9838c097L30-R39) [[2]](diffhunk://#diff-3c90a46c36c3d845d65a410165ecaecd3ee6de6dc843ff34ecd35d1f9838c097L46) [[3]](diffhunk://#diff-8256f9841d5efdc02ef4e7eeca5f5bc19566b90de989cb92790d8b00a727e2a9R7-R12) [[4]](diffhunk://#diff-8256f9841d5efdc02ef4e7eeca5f5bc19566b90de989cb92790d8b00a727e2a9L120-R121)
- Removed tests for conflicting flags involving `--self`.

These changes simplify the update workflow and reduce maintenance overhead by focusing updates solely on installed repositories, not the CLI binary itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the `--self` command flag and self-update capability. The application can no longer automatically update itself through the CLI. Users must obtain application updates from external sources such as package managers or official release repositories instead.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->