### PR TITLE
chore: replace `rustsec/audit-check` action with `pirafrank/audit-check-action`

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,6 +29,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: rustsec/audit-check@858dc40f52ca2b8570b7a997c1c4e35c6fc9a432
+      - name: Setup Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          toolchain: stable
+          rustflags: ""
+      - name: Securty audit
+        uses: pirafrank/audit-check-action@main
+

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -34,6 +34,6 @@ jobs:
         with:
           toolchain: stable
           rustflags: ""
-      - name: Securty audit
-        uses: pirafrank/audit-check-action@main
+      - name: Security audit
+        uses: pirafrank/audit-check-action@v1
 


### PR DESCRIPTION
This pull request updates the Rust security audit workflow to use a different action for running security audits and adds an explicit Rust toolchain setup step. The main changes are:

**Workflow improvements:**

* Replaces the `rustsec/audit-check` action with the `pirafrank/audit-check-action` for running the security audit, which does not depends on node.js. This fixes node.js 20 deprecation warnings on GitHub after the recent move to v24.
* Adds a `Setup Rust` step using the `actions-rust-lang/setup-rust-toolchain` action to ensure the `stable` Rust toolchain is installed before running the audit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated security audit workflow to use the Rust stable toolchain.
  * Replaced the vulnerability scanning action with an updated auditing tool for improved security checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->